### PR TITLE
CLS 27 clean up block data

### DIFF
--- a/pkg/indexer/parser/parser_test.go
+++ b/pkg/indexer/parser/parser_test.go
@@ -95,7 +95,6 @@ func getBlock() types.BlockData {
 					Txs:        nil,
 					SquareSize: 0,
 				},
-				LastCommit: nil,
 			},
 		},
 		ResultBlockResults: types.ResultBlockResults{

--- a/pkg/indexer/parser/parser_test.go
+++ b/pkg/indexer/parser/parser_test.go
@@ -68,10 +68,6 @@ func getBlock() types.BlockData {
 		ResultBlock: types.ResultBlock{
 			BlockID: types.BlockId{
 				Hash: types.Hex{0x0, 0x0, 0x0, 0x2},
-				PartSetHeader: types.PartSetHeader{
-					Total: 0,
-					Hash:  nil,
-				},
 			},
 			Block: &types.Block{
 				Header: types.Header{
@@ -84,10 +80,6 @@ func getBlock() types.BlockData {
 					Time:    time.Time{},
 					LastBlockID: types.BlockId{
 						Hash: types.Hex{0x0, 0x0, 0x0, 0x1},
-						PartSetHeader: types.PartSetHeader{
-							Total: 0,
-							Hash:  nil,
-						},
 					},
 					LastCommitHash:     types.Hex{0x0, 0x0, 0x1, 0x1},
 					DataHash:           types.Hex{0x0, 0x0, 0x1, 0x2},

--- a/pkg/types/block.go
+++ b/pkg/types/block.go
@@ -27,7 +27,7 @@ type Block struct {
 	Header `json:"header"`
 	Data   `json:"data"`
 	// Evidence   types.EvidenceData `json:"evidence"`
-	LastCommit *Commit `json:"last_commit"`
+	// LastCommit *Commit `json:"last_commit"`
 }
 
 // Consensus captures the consensus rules for processing a block in the blockchain,
@@ -85,13 +85,13 @@ type Data struct {
 
 // Commit contains the evidence that a block was committed by a set of validators.
 // NOTE: Commit is empty for height 1, but never nil.
-type Commit struct {
-	// NOTE: The signatures are in order of address to preserve the bonded
-	// ValidatorSet order.
-	// Any peer with a block can gossip signatures by index with a peer without
-	// recalculating the active ValidatorSet.
-	Height     int64             `json:"height,string"`
-	Round      int32             `json:"round"`
-	BlockID    BlockId           `json:"block_id"`
-	Signatures []types.CommitSig `json:"signatures"`
-}
+// type Commit struct {
+// 	// NOTE: The signatures are in order of address to preserve the bonded
+// 	// ValidatorSet order.
+// 	// Any peer with a block can gossip signatures by index with a peer without
+// 	// recalculating the active ValidatorSet.
+// 	Height     int64             `json:"height,string"`
+// 	Round      int32             `json:"round"`
+// 	BlockID    BlockId           `json:"block_id"`
+// 	Signatures []types.CommitSig `json:"signatures"`
+// }

--- a/pkg/types/block.go
+++ b/pkg/types/block.go
@@ -13,14 +13,14 @@ type ResultBlock struct {
 }
 
 type BlockId struct {
-	Hash          Hex           `json:"hash"`
-	PartSetHeader PartSetHeader `json:"parts"`
+	Hash Hex `json:"hash"`
+	// PartSetHeader PartSetHeader `json:"parts"`
 }
 
-type PartSetHeader struct {
-	Total int `json:"total"`
-	Hash  Hex `json:"hash"`
-}
+// type PartSetHeader struct {
+//	Total int `json:"total"`
+//	Hash  Hex `json:"hash"`
+// }
 
 // Block defines the atomic unit of a CometBFT blockchain.
 type Block struct {


### PR DESCRIPTION
- Removed PartSetHeader part of Block.
- Removed LastCommit part of Block.
