### PR TITLE
CLS 5 add messages count for block

### DIFF
--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -1833,6 +1833,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "0.0800000"
                 },
+                "messages_counts": {
+                    "type": "string",
+                    "example": "{MsgPayForBlobs:10,MsgUnjail:1}"
+                },
                 "supply_change": {
                     "type": "string",
                     "example": "8635234"

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -1827,6 +1827,10 @@
                     "type": "string",
                     "example": "0.0800000"
                 },
+                "messages_counts": {
+                    "type": "string",
+                    "example": "{MsgPayForBlobs:10,MsgUnjail:1}"
+                },
                 "supply_change": {
                     "type": "string",
                     "example": "8635234"

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -185,6 +185,9 @@ definitions:
       inflation_rate:
         example: "0.0800000"
         type: string
+      messages_counts:
+        example: '{MsgPayForBlobs:10,MsgUnjail:1}'
+        type: string
       supply_change:
         example: "8635234"
         type: string

--- a/cmd/api/handler/block.go
+++ b/cmd/api/handler/block.go
@@ -65,16 +65,13 @@ func (handler *BlockHandler) Get(c echo.Context) error {
 		return badRequestError(c, err)
 	}
 
+	var block storage.Block
 	if req.Stats {
-		block, err := handler.block.ByHeightWithStats(c.Request().Context(), req.Height)
-		if err := handleError(c, err, handler.block); err != nil {
-			return err
-		}
-
-		return c.JSON(http.StatusOK, responses.NewBlock(block, req.Stats))
+		block, err = handler.block.ByHeightWithStats(c.Request().Context(), req.Height)
+	} else {
+		block, err = handler.block.ByHeight(c.Request().Context(), req.Height)
 	}
 
-	block, err := handler.block.ByHeight(c.Request().Context(), req.Height)
 	if err := handleError(c, err, handler.block); err != nil {
 		return err
 	}

--- a/cmd/api/handler/block.go
+++ b/cmd/api/handler/block.go
@@ -65,6 +65,15 @@ func (handler *BlockHandler) Get(c echo.Context) error {
 		return badRequestError(c, err)
 	}
 
+	if req.Stats {
+		block, err := handler.block.ByHeightWithStats(c.Request().Context(), req.Height)
+		if err := handleError(c, err, handler.block); err != nil {
+			return err
+		}
+
+		return c.JSON(http.StatusOK, responses.NewBlock(block, req.Stats))
+	}
+
 	block, err := handler.block.ByHeight(c.Request().Context(), req.Height)
 	if err := handleError(c, err, handler.block); err != nil {
 		return err
@@ -111,14 +120,20 @@ func (handler *BlockHandler) List(c echo.Context) error {
 	}
 	req.SetDefault()
 
-	blocks, err := handler.block.ListWithStats(c.Request().Context(), req.Stats, req.Limit, req.Offset, pgSort(req.Sort))
+	var blocks []*storage.Block
+	if req.Stats {
+		blocks, err = handler.block.ListWithStats(c.Request().Context(), req.Limit, req.Offset, pgSort(req.Sort))
+	} else {
+		blocks, err = handler.block.List(c.Request().Context(), req.Limit, req.Offset, pgSort(req.Sort))
+	}
+
 	if err := handleError(c, err, handler.block); err != nil {
 		return err
 	}
 
 	response := make([]responses.Block, len(blocks))
 	for i := range blocks {
-		response[i] = responses.NewBlock(blocks[i], req.Stats)
+		response[i] = responses.NewBlock(*blocks[i], req.Stats)
 	}
 
 	return returnArray(c, response)

--- a/cmd/api/handler/responses/block.go
+++ b/cmd/api/handler/responses/block.go
@@ -64,23 +64,31 @@ func (Block) SearchType() string {
 }
 
 type BlockStats struct {
-	TxCount       uint64 `example:"12"          json:"tx_count"       swaggertype:"integer"`
-	EventsCount   uint64 `example:"18"          json:"events_count"   swaggertype:"integer"`
-	BlobsSize     uint64 `example:"12354"       json:"blobs_size"     swaggertype:"integer"`
-	Fee           string `example:"28347628346" json:"fee"            swaggertype:"string"`
-	SupplyChange  string `example:"8635234"     json:"supply_change"  swaggertype:"string"`
-	InflationRate string `example:"0.0800000"   json:"inflation_rate" swaggertype:"string"`
-	BlockTime     uint64 `example:"12354"       json:"block_time"     swaggertype:"integer"`
+	TxCount        uint64           `example:"12"                              json:"tx_count"        swaggertype:"integer"`
+	EventsCount    uint64           `example:"18"                              json:"events_count"    swaggertype:"integer"`
+	BlobsSize      uint64           `example:"12354"                           json:"blobs_size"      swaggertype:"integer"`
+	Fee            string           `example:"28347628346"                     json:"fee"             swaggertype:"string"`
+	SupplyChange   string           `example:"8635234"                         json:"supply_change"   swaggertype:"string"`
+	InflationRate  string           `example:"0.0800000"                       json:"inflation_rate"  swaggertype:"string"`
+	BlockTime      uint64           `example:"12354"                           json:"block_time"      swaggertype:"integer"`
+	MessagesCounts map[string]int64 `example:"{MsgPayForBlobs:10,MsgUnjail:1}" json:"messages_counts" swaggertype:"object"`
 }
 
 func NewBlockStats(stats storage.BlockStats) *BlockStats {
-	return &BlockStats{
-		TxCount:       stats.TxCount,
-		EventsCount:   stats.EventsCount,
-		BlobsSize:     stats.BlobsSize,
-		Fee:           stats.Fee.String(),
-		SupplyChange:  stats.SupplyChange.String(),
-		InflationRate: stats.InflationRate.String(),
-		BlockTime:     stats.BlockTime,
+	bs := BlockStats{
+		TxCount:        stats.TxCount,
+		EventsCount:    stats.EventsCount,
+		BlobsSize:      stats.BlobsSize,
+		Fee:            stats.Fee.String(),
+		SupplyChange:   stats.SupplyChange.String(),
+		InflationRate:  stats.InflationRate.String(),
+		BlockTime:      stats.BlockTime,
+		MessagesCounts: make(map[string]int64),
 	}
+
+	for key, value := range stats.MessagesCounts {
+		bs.MessagesCounts[key.String()] = value
+	}
+
+	return &bs
 }

--- a/cmd/api/handler/responses/block.go
+++ b/cmd/api/handler/responses/block.go
@@ -71,7 +71,7 @@ type BlockStats struct {
 	SupplyChange   string           `example:"8635234"                         json:"supply_change"   swaggertype:"string"`
 	InflationRate  string           `example:"0.0800000"                       json:"inflation_rate"  swaggertype:"string"`
 	BlockTime      uint64           `example:"12354"                           json:"block_time"      swaggertype:"integer"`
-	MessagesCounts map[string]int64 `example:"{MsgPayForBlobs:10,MsgUnjail:1}" json:"messages_counts" swaggertype:"object"`
+	MessagesCounts map[string]int64 `example:"{MsgPayForBlobs:10,MsgUnjail:1}" json:"messages_counts" swaggertype:"string"`
 }
 
 func NewBlockStats(stats storage.BlockStats) *BlockStats {

--- a/cmd/api/handler/responses/block_test.go
+++ b/cmd/api/handler/responses/block_test.go
@@ -1,0 +1,219 @@
+package responses
+
+import (
+	"github.com/dipdup-io/celestia-indexer/internal/storage"
+	storageTypes "github.com/dipdup-io/celestia-indexer/internal/storage/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBlock_SearchType(t *testing.T) {
+	block := Block{}
+	searchType := block.SearchType()
+	assert.EqualValues(t, "block", searchType)
+}
+
+func TestNewBlock(t *testing.T) {
+	type args struct {
+		block     storage.Block
+		withStats bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want Block
+	}{
+		{
+			name: "without stats",
+			args: args{
+				block: storage.Block{
+					Id:           1000,
+					Height:       1000,
+					Time:         time.Time{},
+					VersionBlock: 10,
+					VersionApp:   11,
+					MessageTypes: storageTypes.MsgTypeBits{
+						Bits: 1,
+					},
+					Hash:               []byte{0x01},
+					ParentHash:         []byte{0x02},
+					LastCommitHash:     []byte{0x03},
+					DataHash:           []byte{0x04},
+					ValidatorsHash:     []byte{0x05},
+					NextValidatorsHash: []byte{0x06},
+					ConsensusHash:      []byte{0x07},
+					AppHash:            []byte{0x08},
+					LastResultsHash:    []byte{0x09},
+					EvidenceHash:       []byte{0x10},
+					ProposerAddress:    []byte{0x11},
+					ChainId:            "dipdup",
+				},
+				withStats: false,
+			},
+			want: Block{
+				Id:                 1000,
+				Height:             1000,
+				Time:               time.Time{},
+				VersionBlock:       "10",
+				VersionApp:         "11",
+				Hash:               []byte{0x01},
+				ParentHash:         []byte{0x02},
+				LastCommitHash:     []byte{0x03},
+				DataHash:           []byte{0x04},
+				ValidatorsHash:     []byte{0x05},
+				NextValidatorsHash: []byte{0x06},
+				ConsensusHash:      []byte{0x07},
+				AppHash:            []byte{0x08},
+				LastResultsHash:    []byte{0x09},
+				EvidenceHash:       []byte{0x10},
+				ProposerAddress:    []byte{0x11},
+				MessageTypes:       []storageTypes.MsgType{storageTypes.MsgUnknown},
+				Stats:              nil,
+			},
+		},
+
+		{
+			name: "with stats",
+			args: args{
+				block: storage.Block{
+					Id:           1000,
+					Height:       1000,
+					Time:         time.Time{},
+					VersionBlock: 10,
+					VersionApp:   11,
+					MessageTypes: storageTypes.MsgTypeBits{
+						Bits: 1,
+					},
+					Hash:               []byte{0x01},
+					ParentHash:         []byte{0x02},
+					LastCommitHash:     []byte{0x03},
+					DataHash:           []byte{0x04},
+					ValidatorsHash:     []byte{0x05},
+					NextValidatorsHash: []byte{0x06},
+					ConsensusHash:      []byte{0x07},
+					AppHash:            []byte{0x08},
+					LastResultsHash:    []byte{0x09},
+					EvidenceHash:       []byte{0x10},
+					ProposerAddress:    []byte{0x11},
+					ChainId:            "dipdup",
+					Stats: storage.BlockStats{
+						Id:            1000,
+						Height:        1000,
+						Time:          time.Time{},
+						TxCount:       6,
+						EventsCount:   10,
+						BlobsSize:     1234,
+						BlockTime:     11000,
+						SupplyChange:  decimal.NewFromInt(123),
+						InflationRate: decimal.NewFromFloat(0.08),
+						Fee:           decimal.NewFromInt(125),
+						MessagesCounts: map[storageTypes.MsgType]int64{
+							storageTypes.MsgSend:        1,
+							storageTypes.MsgPayForBlobs: 2,
+							storageTypes.MsgDelegate:    3,
+						},
+					},
+				},
+				withStats: true,
+			},
+			want: Block{
+				Id:                 1000,
+				Height:             1000,
+				Time:               time.Time{},
+				VersionBlock:       "10",
+				VersionApp:         "11",
+				Hash:               []byte{0x01},
+				ParentHash:         []byte{0x02},
+				LastCommitHash:     []byte{0x03},
+				DataHash:           []byte{0x04},
+				ValidatorsHash:     []byte{0x05},
+				NextValidatorsHash: []byte{0x06},
+				ConsensusHash:      []byte{0x07},
+				AppHash:            []byte{0x08},
+				LastResultsHash:    []byte{0x09},
+				EvidenceHash:       []byte{0x10},
+				ProposerAddress:    []byte{0x11},
+				MessageTypes:       []storageTypes.MsgType{storageTypes.MsgUnknown},
+				Stats: &BlockStats{
+					TxCount:       6,
+					EventsCount:   10,
+					BlobsSize:     1234,
+					Fee:           "125",
+					SupplyChange:  "123",
+					InflationRate: "0.08",
+					BlockTime:     11000,
+					MessagesCounts: map[string]int64{
+						"MsgSend":        1,
+						"MsgPayForBlobs": 2,
+						"MsgDelegate":    3,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewBlock(tt.args.block, tt.args.withStats); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewBlock() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewBlockStats(t *testing.T) {
+	type args struct {
+		stats storage.BlockStats
+	}
+	tests := []struct {
+		name string
+		args args
+		want *BlockStats
+	}{
+		{
+			name: "with msgs counts",
+			args: args{
+				stats: storage.BlockStats{
+					Id:            100,
+					Height:        100,
+					Time:          time.Time{},
+					TxCount:       6,
+					EventsCount:   10,
+					BlobsSize:     1234,
+					BlockTime:     11000,
+					SupplyChange:  decimal.NewFromInt(123),
+					InflationRate: decimal.NewFromFloat(0.08),
+					Fee:           decimal.NewFromInt(125),
+					MessagesCounts: map[storageTypes.MsgType]int64{
+						storageTypes.MsgSend:        1,
+						storageTypes.MsgPayForBlobs: 2,
+						storageTypes.MsgDelegate:    3,
+					},
+				},
+			},
+			want: &BlockStats{
+				TxCount:       6,
+				EventsCount:   10,
+				BlobsSize:     1234,
+				Fee:           "125",
+				SupplyChange:  "123",
+				InflationRate: "0.08",
+				BlockTime:     11000,
+				MessagesCounts: map[string]int64{
+					"MsgSend":        1,
+					"MsgPayForBlobs": 2,
+					"MsgDelegate":    3,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewBlockStats(tt.args.stats); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewBlockStats() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/block.go
+++ b/internal/storage/block.go
@@ -19,7 +19,7 @@ type IBlock interface {
 	ByHeight(ctx context.Context, height uint64) (Block, error)
 	ByHeightWithStats(ctx context.Context, height uint64) (Block, error)
 	ByHash(ctx context.Context, hash []byte) (Block, error)
-	ListWithStats(ctx context.Context, stats bool, limit, offset uint64, order storage.SortOrder) ([]Block, error)
+	ListWithStats(ctx context.Context, limit, offset uint64, order storage.SortOrder) ([]*Block, error)
 }
 
 // Block -

--- a/internal/storage/block.go
+++ b/internal/storage/block.go
@@ -17,6 +17,7 @@ type IBlock interface {
 
 	Last(ctx context.Context) (Block, error)
 	ByHeight(ctx context.Context, height uint64) (Block, error)
+	ByHeightWithStats(ctx context.Context, height uint64) (Block, error)
 	ByHash(ctx context.Context, hash []byte) (Block, error)
 	ListWithStats(ctx context.Context, stats bool, limit, offset uint64, order storage.SortOrder) ([]Block, error)
 }

--- a/internal/storage/block_stats.go
+++ b/internal/storage/block_stats.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"github.com/dipdup-io/celestia-indexer/internal/storage/types"
 	"time"
 
 	pkgTypes "github.com/dipdup-io/celestia-indexer/pkg/types"
@@ -28,6 +29,8 @@ type BlockStats struct {
 	SupplyChange  decimal.Decimal `bun:",type:numeric"    comment:"Change of total supply in the block"                     stats:"func:min max sum avg"`
 	InflationRate decimal.Decimal `bun:",type:numeric"    comment:"Inflation rate"                                          stats:"func:min max avg"`
 	Fee           decimal.Decimal `bun:"fee,type:numeric" comment:"Summary block fee"                                       stats:"func:min max sum avg"`
+
+	MessagesCounts map[types.MsgType]int64 `bun:"-"`
 }
 
 func (BlockStats) TableName() string {

--- a/internal/storage/mock/block.go
+++ b/internal/storage/mock/block.go
@@ -391,18 +391,18 @@ func (c *IBlockListCall) DoAndReturn(f func(context.Context, uint64, uint64, sto
 }
 
 // ListWithStats mocks base method.
-func (m *MockIBlock) ListWithStats(ctx context.Context, stats bool, limit, offset uint64, order storage0.SortOrder) ([]storage.Block, error) {
+func (m *MockIBlock) ListWithStats(ctx context.Context, limit, offset uint64, order storage0.SortOrder) ([]*storage.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListWithStats", ctx, stats, limit, offset, order)
-	ret0, _ := ret[0].([]storage.Block)
+	ret := m.ctrl.Call(m, "ListWithStats", ctx, limit, offset, order)
+	ret0, _ := ret[0].([]*storage.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListWithStats indicates an expected call of ListWithStats.
-func (mr *MockIBlockMockRecorder) ListWithStats(ctx, stats, limit, offset, order any) *IBlockListWithStatsCall {
+func (mr *MockIBlockMockRecorder) ListWithStats(ctx, limit, offset, order any) *IBlockListWithStatsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWithStats", reflect.TypeOf((*MockIBlock)(nil).ListWithStats), ctx, stats, limit, offset, order)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWithStats", reflect.TypeOf((*MockIBlock)(nil).ListWithStats), ctx, limit, offset, order)
 	return &IBlockListWithStatsCall{Call: call}
 }
 
@@ -412,19 +412,19 @@ type IBlockListWithStatsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *IBlockListWithStatsCall) Return(arg0 []storage.Block, arg1 error) *IBlockListWithStatsCall {
+func (c *IBlockListWithStatsCall) Return(arg0 []*storage.Block, arg1 error) *IBlockListWithStatsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *IBlockListWithStatsCall) Do(f func(context.Context, bool, uint64, uint64, storage0.SortOrder) ([]storage.Block, error)) *IBlockListWithStatsCall {
+func (c *IBlockListWithStatsCall) Do(f func(context.Context, uint64, uint64, storage0.SortOrder) ([]*storage.Block, error)) *IBlockListWithStatsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *IBlockListWithStatsCall) DoAndReturn(f func(context.Context, bool, uint64, uint64, storage0.SortOrder) ([]storage.Block, error)) *IBlockListWithStatsCall {
+func (c *IBlockListWithStatsCall) DoAndReturn(f func(context.Context, uint64, uint64, storage0.SortOrder) ([]*storage.Block, error)) *IBlockListWithStatsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/mock/block.go
+++ b/internal/storage/mock/block.go
@@ -118,6 +118,45 @@ func (c *IBlockByHeightCall) DoAndReturn(f func(context.Context, uint64) (storag
 	return c
 }
 
+// ByHeightWithStats mocks base method.
+func (m *MockIBlock) ByHeightWithStats(ctx context.Context, height uint64) (storage.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ByHeightWithStats", ctx, height)
+	ret0, _ := ret[0].(storage.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ByHeightWithStats indicates an expected call of ByHeightWithStats.
+func (mr *MockIBlockMockRecorder) ByHeightWithStats(ctx, height any) *IBlockByHeightWithStatsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByHeightWithStats", reflect.TypeOf((*MockIBlock)(nil).ByHeightWithStats), ctx, height)
+	return &IBlockByHeightWithStatsCall{Call: call}
+}
+
+// IBlockByHeightWithStatsCall wrap *gomock.Call
+type IBlockByHeightWithStatsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *IBlockByHeightWithStatsCall) Return(arg0 storage.Block, arg1 error) *IBlockByHeightWithStatsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *IBlockByHeightWithStatsCall) Do(f func(context.Context, uint64) (storage.Block, error)) *IBlockByHeightWithStatsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *IBlockByHeightWithStatsCall) DoAndReturn(f func(context.Context, uint64) (storage.Block, error)) *IBlockByHeightWithStatsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CursorList mocks base method.
 func (m *MockIBlock) CursorList(ctx context.Context, id, limit uint64, order storage0.SortOrder, cmp storage0.Comparator) ([]*storage.Block, error) {
 	m.ctrl.T.Helper()

--- a/internal/storage/postgres/block.go
+++ b/internal/storage/postgres/block.go
@@ -46,7 +46,7 @@ func (b *Blocks) Last(ctx context.Context) (block storage.Block, err error) {
 	return
 }
 
-// ByHeight -
+// ByHash -
 func (b *Blocks) ByHash(ctx context.Context, hash []byte) (block storage.Block, err error) {
 	err = b.DB().NewSelect().
 		Model(&block).
@@ -58,22 +58,17 @@ func (b *Blocks) ByHash(ctx context.Context, hash []byte) (block storage.Block, 
 }
 
 // ListWithStats -
-func (b *Blocks) ListWithStats(ctx context.Context, stats bool, limit, offset uint64, order sdk.SortOrder) (blocks []storage.Block, err error) {
+func (b *Blocks) ListWithStats(ctx context.Context, limit, offset uint64, order sdk.SortOrder) (blocks []*storage.Block, err error) {
 	subQuery := b.DB().NewSelect().Model(&blocks)
 	subQuery = postgres.Pagination(subQuery, limit, offset, order)
 
-	if stats {
-		query := b.DB().NewSelect().
-			ColumnExpr("block.*").
-			ColumnExpr("stats.id AS stats__id, stats.height AS stats__height, stats.time AS stats__time, stats.tx_count AS stats__tx_count, stats.events_count AS stats__events_count, stats.blobs_size AS stats__blobs_size, stats.block_time AS stats__block_time, stats.supply_change AS stats__supply_change, stats.inflation_rate AS stats__inflation_rate, stats.fee AS stats__fee").
-			TableExpr("(?) as block", subQuery).
-			Join("LEFT JOIN block_stats as stats").
-			JoinOn("stats.height = block.height")
-		query = sortScope(query, "block.id", order)
-		err = query.Scan(ctx, &blocks)
-		return
-	}
-
-	err = subQuery.Scan(ctx)
+	query := b.DB().NewSelect().
+		ColumnExpr("block.*").
+		ColumnExpr("stats.id AS stats__id, stats.height AS stats__height, stats.time AS stats__time, stats.tx_count AS stats__tx_count, stats.events_count AS stats__events_count, stats.blobs_size AS stats__blobs_size, stats.block_time AS stats__block_time, stats.supply_change AS stats__supply_change, stats.inflation_rate AS stats__inflation_rate, stats.fee AS stats__fee").
+		TableExpr("(?) as block", subQuery).
+		Join("LEFT JOIN block_stats as stats").
+		JoinOn("stats.height = block.height")
+	query = sortScope(query, "block.id", order)
+	err = query.Scan(ctx, &blocks)
 	return
 }

--- a/internal/storage/postgres/block.go
+++ b/internal/storage/postgres/block.go
@@ -25,6 +25,15 @@ func NewBlocks(db *database.Bun) *Blocks {
 func (b *Blocks) ByHeight(ctx context.Context, height uint64) (block storage.Block, err error) {
 	err = b.DB().NewSelect().Model(&block).
 		Where("block.height = ?", height).
+		Limit(1).
+		Scan(ctx)
+	return
+}
+
+// ByHeightWithStats -
+func (b *Blocks) ByHeightWithStats(ctx context.Context, height uint64) (block storage.Block, err error) {
+	err = b.DB().NewSelect().Model(&block).
+		Where("block.height = ?", height).
 		Relation("Stats").
 		Limit(1).
 		Scan(ctx)

--- a/internal/storage/postgres/storage_test.go
+++ b/internal/storage/postgres/storage_test.go
@@ -181,7 +181,7 @@ func (s *StorageTestSuite) TestBlockListWithStats() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer ctxCancel()
 
-	blocks, err := s.storage.Blocks.ListWithStats(ctx, true, 10, 0, sdk.SortOrderDesc)
+	blocks, err := s.storage.Blocks.ListWithStats(ctx, 10, 0, sdk.SortOrderDesc)
 	s.Require().NoError(err)
 	s.Require().Len(blocks, 2)
 
@@ -192,7 +192,7 @@ func (s *StorageTestSuite) TestBlockListWithStats() {
 	s.Require().EqualValues(0, block.Stats.TxCount)
 	s.Require().EqualValues(11000, block.Stats.BlockTime)
 
-	blocks, err = s.storage.Blocks.ListWithStats(ctx, false, 10, 0, sdk.SortOrderDesc)
+	blocks, err = s.storage.Blocks.List(ctx, 10, 0, sdk.SortOrderDesc)
 	s.Require().NoError(err)
 	s.Require().Len(blocks, 2)
 
@@ -200,8 +200,7 @@ func (s *StorageTestSuite) TestBlockListWithStats() {
 	s.Require().EqualValues(1000, block.Height)
 	s.Require().EqualValues(1, block.VersionApp)
 	s.Require().EqualValues(11, block.VersionBlock)
-	s.Require().EqualValues(0, block.Stats.TxCount)
-	s.Require().EqualValues(0, block.Stats.BlockTime)
+	s.Require().EqualValues(storage.BlockStats{}, block.Stats)
 }
 
 func (s *StorageTestSuite) TestAddressByHash() {

--- a/internal/storage/postgres/storage_test.go
+++ b/internal/storage/postgres/storage_test.go
@@ -132,7 +132,8 @@ func (s *StorageTestSuite) TestBlockByHeight() {
 }
 
 func (s *StorageTestSuite) TestBlockByHeightWithStats() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 
 	block, err := s.storage.Blocks.ByHeightWithStats(ctx, 1000)
@@ -153,6 +154,12 @@ func (s *StorageTestSuite) TestBlockByHeightWithStats() {
 		SupplyChange:  decimal.NewFromInt(30930476),
 		InflationRate: decimal.NewFromFloat(0.08),
 		Fee:           decimal.NewFromInt(2873468273),
+		MessagesCounts: map[types.MsgType]int64{
+			types.MsgDelegate:                1,
+			types.MsgPayForBlobs:             1,
+			types.MsgUnjail:                  1,
+			types.MsgWithdrawDelegatorReward: 1,
+		},
 	}
 	s.Require().Equal(expectedStats, block.Stats)
 

--- a/internal/storage/postgres/storage_test.go
+++ b/internal/storage/postgres/storage_test.go
@@ -132,8 +132,7 @@ func (s *StorageTestSuite) TestBlockByHeight() {
 }
 
 func (s *StorageTestSuite) TestBlockByHeightWithStats() {
-	// ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer ctxCancel()
 
 	block, err := s.storage.Blocks.ByHeightWithStats(ctx, 1000)
@@ -198,6 +197,12 @@ func (s *StorageTestSuite) TestBlockListWithStats() {
 	s.Require().EqualValues(11, block.VersionBlock)
 	s.Require().EqualValues(0, block.Stats.TxCount)
 	s.Require().EqualValues(11000, block.Stats.BlockTime)
+	s.Require().EqualValues(map[types.MsgType]int64{
+		types.MsgWithdrawDelegatorReward: 1,
+		types.MsgDelegate:                1,
+		types.MsgUnjail:                  1,
+		types.MsgPayForBlobs:             1,
+	}, block.Stats.MessagesCounts)
 
 	blocks, err = s.storage.Blocks.List(ctx, 10, 0, sdk.SortOrderDesc)
 	s.Require().NoError(err)

--- a/internal/storage/postgres/storage_test.go
+++ b/internal/storage/postgres/storage_test.go
@@ -123,7 +123,7 @@ func (s *StorageTestSuite) TestBlockByHeight() {
 	s.Require().EqualValues(1000, block.Height)
 	s.Require().EqualValues(1, block.VersionApp)
 	s.Require().EqualValues(11, block.VersionBlock)
-	s.Require().EqualValues(0, block.Stats.TxCount)
+	s.Require().Equal(storage.BlockStats{}, block.Stats)
 
 	hash, err := hex.DecodeString("6A30C94091DA7C436D64E62111D6890D772E351823C41496B4E52F28F5B000BF")
 	s.Require().NoError(err)


### PR DESCRIPTION
- Added ByHeightWithStats method to IBlock and postgres impl.
- Fix unit test on BlockByHeigh method to check that stats are emty.
- Added ByHeightWithStats unit test.
- Added Make ListsWithStats permanent with stats.
- Implemented logic on count msgs types for block stats.
- Added block stats to response result.
- Updates docs.
- Updated ListsWithStats to get stats on msgs counts. Updated tests.
