### PR TITLE
CLS 63 fix stats on block

### DIFF
--- a/internal/storage/postgres/block_stats_test.go
+++ b/internal/storage/postgres/block_stats_test.go
@@ -1,0 +1,1 @@
+package postgres

--- a/internal/storage/postgres/block_stats_test.go
+++ b/internal/storage/postgres/block_stats_test.go
@@ -1,1 +1,125 @@
 package postgres
+
+import (
+	"context"
+	"database/sql"
+	"github.com/dipdup-io/celestia-indexer/internal/storage"
+	storageTypes "github.com/dipdup-io/celestia-indexer/internal/storage/types"
+	"github.com/dipdup-net/go-lib/config"
+	"github.com/dipdup-net/go-lib/database"
+	"github.com/go-testfixtures/testfixtures/v3"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"time"
+)
+
+// BlockStatsTestSuite -
+type BlockStatsTestSuite struct {
+	suite.Suite
+	psqlContainer *database.PostgreSQLContainer
+	storage       Storage
+}
+
+// SetupSuite -
+func (s *BlockStatsTestSuite) SetupSuite() {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	psqlContainer, err := database.NewPostgreSQLContainer(ctx, database.PostgreSQLContainerConfig{
+		User:     "user",
+		Password: "password",
+		Database: "db_test",
+		Port:     5432,
+		Image:    "timescale/timescaledb:latest-pg15",
+	})
+	s.Require().NoError(err)
+	s.psqlContainer = psqlContainer
+
+	strg, err := Create(ctx, config.Database{
+		Kind:     config.DBKindPostgres,
+		User:     s.psqlContainer.Config.User,
+		Database: s.psqlContainer.Config.Database,
+		Password: s.psqlContainer.Config.Password,
+		Host:     s.psqlContainer.Config.Host,
+		Port:     s.psqlContainer.MappedPort().Int(),
+	})
+	s.Require().NoError(err)
+	s.storage = strg
+
+	db, err := sql.Open("postgres", s.psqlContainer.GetDSN())
+	s.Require().NoError(err)
+
+	fixtures, err := testfixtures.New(
+		testfixtures.Database(db),
+		testfixtures.Dialect("timescaledb"),
+		testfixtures.Directory("../../../test/data"),
+		testfixtures.UseAlterConstraint(),
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(fixtures.Load())
+	s.Require().NoError(db.Close())
+}
+
+// TearDownSuite -
+func (s *BlockStatsTestSuite) TearDownSuite() {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	s.Require().NoError(s.storage.Close())
+	s.Require().NoError(s.psqlContainer.Terminate(ctx))
+}
+
+func (s *BlockStatsTestSuite) TestByHeight() {
+	tests := []struct {
+		name   string
+		height uint64
+		want   storage.BlockStats
+	}{
+		{
+			name:   "height 1000",
+			height: 1000,
+			want: storage.BlockStats{
+				Id:           2,
+				Height:       1000,
+				SupplyChange: decimal.NewFromInt(30930476),
+				MessagesCounts: map[storageTypes.MsgType]int64{
+					storageTypes.MsgWithdrawDelegatorReward: 1,
+					storageTypes.MsgDelegate:                1,
+					storageTypes.MsgUnjail:                  1,
+					storageTypes.MsgPayForBlobs:             1,
+				},
+			},
+		},
+		{
+			name:   "height 999",
+			height: 999,
+			want: storage.BlockStats{
+				Id:           1,
+				Height:       999,
+				SupplyChange: decimal.NewFromInt(20930476),
+				MessagesCounts: map[storageTypes.MsgType]int64{
+					storageTypes.MsgCreateValidator: 1,
+				},
+			},
+		},
+	}
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelCtx()
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			got, err := s.storage.BlockStats.ByHeight(ctx, tt.height)
+			s.Require().NoError(err)
+			s.Require().Equal(tt.want.Id, got.Id)
+			s.Require().Equal(tt.want.Height, got.Height)
+			s.Require().Equal(tt.want.SupplyChange, got.SupplyChange)
+			s.Require().Equal(tt.want.MessagesCounts, got.MessagesCounts)
+		})
+	}
+}
+
+func TestSuiteBlockStats_Run(t *testing.T) {
+	suite.Run(t, new(BlockStatsTestSuite))
+}

--- a/internal/storage/postgres/stats_test.go
+++ b/internal/storage/postgres/stats_test.go
@@ -94,7 +94,6 @@ func (s *StatsTestSuite) TestCount() {
 
 	for i := range tests {
 		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer ctxCancel()
 
 		count, err := s.storage.Stats.Count(ctx, storage.CountRequest{
 			Table: tests[i].table,
@@ -102,6 +101,8 @@ func (s *StatsTestSuite) TestCount() {
 		})
 		s.Require().NoError(err)
 		s.Require().EqualValues(tests[i].want, count)
+
+		ctxCancel()
 	}
 }
 
@@ -124,7 +125,6 @@ func (s *StatsTestSuite) TestCountNoData() {
 
 	for i := range tests {
 		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer ctxCancel()
 
 		count, err := s.storage.Stats.Count(ctx, storage.CountRequest{
 			Table: tests[i].table,
@@ -132,6 +132,8 @@ func (s *StatsTestSuite) TestCountNoData() {
 		})
 		s.Require().NoError(err)
 		s.Require().EqualValues("0", count)
+
+		ctxCancel()
 	}
 }
 
@@ -192,7 +194,6 @@ func (s *StatsTestSuite) TestSummaryBlock() {
 
 	for i := range tests {
 		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer ctxCancel()
 
 		summary, err := s.storage.Stats.Summary(ctx, storage.SummaryRequest{
 			CountRequest: storage.CountRequest{
@@ -206,6 +207,8 @@ func (s *StatsTestSuite) TestSummaryBlock() {
 
 		parts := strings.Split(summary, ".")
 		s.Require().Equal(tests[i].want, parts[0])
+
+		ctxCancel()
 	}
 }
 
@@ -509,7 +512,6 @@ func (s *StatsTestSuite) TestHistogram() {
 
 	for i := range tests {
 		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer ctxCancel()
 
 		histogram, err := s.storage.Stats.Histogram(ctx,
 			storage.HistogramRequest{
@@ -530,6 +532,8 @@ func (s *StatsTestSuite) TestHistogram() {
 		parts := strings.Split(item.Value, ".")
 		s.Require().Equal(tests[i].want, parts[0])
 		s.Require().True(item.Time.Equal(tests[i].wantDate))
+
+		ctxCancel()
 	}
 }
 
@@ -647,7 +651,6 @@ func (s *StatsTestSuite) TestHistogramCount() {
 
 	for i := range tests {
 		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer ctxCancel()
 
 		histogram, err := s.storage.Stats.HistogramCount(ctx,
 			storage.HistogramCountRequest{
@@ -663,6 +666,8 @@ func (s *StatsTestSuite) TestHistogramCount() {
 		item := histogram[0]
 		s.Require().Equal(tests[i].want, item.Value)
 		s.Require().True(item.Time.Equal(tests[i].wantDate))
+
+		ctxCancel()
 	}
 }
 


### PR DESCRIPTION
- Added msgs counts on block/:height/stats resp.
- REFACTOR: stats_test with explicit call of context cancel.
- Added unit test for block_stats ByHeight.
